### PR TITLE
Fix setting scope on context

### DIFF
--- a/middleware/oauth2.go
+++ b/middleware/oauth2.go
@@ -16,7 +16,8 @@ func ScopesAuth(scopes ...string) ginoauth2.AccessCheckFunction {
 
 	return func(tc *ginoauth2.TokenContainer, ctx *gin.Context) bool {
 		for scope := range authScopes {
-			if value, ok := tc.Scopes[scope]; !ok {
+			value, ok := tc.Scopes[scope]
+			if !ok {
 				return false
 			}
 			ctx.Set(scope, value)

--- a/middleware/oauth2_test.go
+++ b/middleware/oauth2_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	ginoauth2 "github.com/zalando/gin-oauth2"
 )
 
@@ -49,7 +50,7 @@ func TestScopesAuth(t *testing.T) {
 	} {
 		t.Run(tc.msg, func(t *testing.T) {
 			fn := ScopesAuth(tc.scopes...)
-			if tc.accepted != fn(tc.container, nil) {
+			if tc.accepted != fn(tc.container, &gin.Context{Keys: make(map[string]interface{})}) {
 				t.Errorf("expected accepted: %t, got %t", tc.accepted, fn(tc.container, nil))
 			}
 		})


### PR DESCRIPTION
There was a small bug in #7 with the scoping of the `value` parameter.

This fixes the issue and the tests.

Created #8 to setup travis for running tests on PRs.