### PR TITLE
Fix tracing span options to be scoped to a single request

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -85,7 +85,7 @@ func templatesApiGotmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/api.gotmpl", size: 7399, mode: os.FileMode(420), modTime: time.Unix(1538915872, 0)}
+	info := bindataFileInfo{name: "templates/api.gotmpl", size: 7399, mode: os.FileMode(420), modTime: time.Unix(1541090531, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -105,7 +105,7 @@ func templatesConfigGotmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/config.gotmpl", size: 1744, mode: os.FileMode(420), modTime: time.Unix(1535473472, 0)}
+	info := bindataFileInfo{name: "templates/config.gotmpl", size: 1744, mode: os.FileMode(420), modTime: time.Unix(1535470076, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func templatesParameterGotmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/parameter.gotmpl", size: 18034, mode: os.FileMode(420), modTime: time.Unix(1536181811, 0)}
+	info := bindataFileInfo{name: "templates/parameter.gotmpl", size: 18034, mode: os.FileMode(420), modTime: time.Unix(1537954913, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -16,6 +16,7 @@ const (
 // succeeds. Otherwise it will start a new span which is not a child.
 func InitSpan(tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
+		opts := opts
 		spanCtx, err := tracer.Extract(opentracing.TextMap, opentracing.HTTPHeadersCarrier(ctx.Request.Header))
 		if err == nil {
 			// if we got a span context from the headers,


### PR DESCRIPTION
This fixes a problem where the span options slice wasn't scoped to the middleware function and thus would be reused and extended for each request. This caused weird traces as all traces would have the parent traces of all previous requests added to the span options slice.

This also explains the memory blowing up with opentracing enabled.