### PR TITLE
Uses operation security scopes

### DIFF
--- a/example/restapi/api.go
+++ b/example/restapi/api.go
@@ -218,7 +218,7 @@ func initializeRoutes(enableAuth bool, tokenURL string, tracer opentracing.Trace
 			routeTokenURL = "https://info.services.auth.zalando.com/oauth2/tokeninfo"
 		}
 		routes.CreateInfrastructureAccount.Auth = ginoauth2.Auth(
-			middleware.ScopesAuth("uid"),
+			middleware.ScopesAuth("uid", "write"),
 			oauth2.Endpoint{
 				TokenURL: routeTokenURL,
 			},
@@ -441,7 +441,7 @@ func initializeRoutes(enableAuth bool, tokenURL string, tracer opentracing.Trace
 			routeTokenURL = "https://info.services.auth.zalando.com/oauth2/tokeninfo"
 		}
 		routes.UpdateInfrastructureAccount.Auth = ginoauth2.Auth(
-			middleware.ScopesAuth("uid"),
+			middleware.ScopesAuth("uid", "write"),
 			oauth2.Endpoint{
 				TokenURL: routeTokenURL,
 			},

--- a/example/restapi/embedded_spec.go
+++ b/example/restapi/embedded_spec.go
@@ -37,6 +37,13 @@ func init() {
   "paths": {
     "/infrastructure-accounts": {
       "get": {
+        "security": [
+          {
+            "OAuth2": [
+              "uid"
+            ]
+          }
+        ],
         "tags": [
           "InfrastructureAccounts"
         ],
@@ -72,6 +79,14 @@ func init() {
         }
       },
       "post": {
+        "security": [
+          {
+            "OAuth2": [
+              "uid",
+              "write"
+            ]
+          }
+        ],
         "description": "Creates a new infrastructure account\n",
         "tags": [
           "InfrastructureAccounts"
@@ -155,6 +170,14 @@ func init() {
         }
       },
       "patch": {
+        "security": [
+          {
+            "OAuth2": [
+              "uid",
+              "write"
+            ]
+          }
+        ],
         "description": "update an infrastructure account.",
         "tags": [
           "InfrastructureAccounts"
@@ -1130,7 +1153,8 @@ func init() {
       "flow": "password",
       "tokenUrl": "https://info.services.auth.zalando.com/oauth2/tokeninfo",
       "scopes": {
-        "uid": "Unique identifier of the user accessing the service."
+        "uid": "Unique identifier of the user accessing the service.",
+        "write": "Allows write"
       }
     }
   },
@@ -1162,6 +1186,13 @@ func init() {
   "paths": {
     "/infrastructure-accounts": {
       "get": {
+        "security": [
+          {
+            "OAuth2": [
+              "uid"
+            ]
+          }
+        ],
         "tags": [
           "InfrastructureAccounts"
         ],
@@ -1197,6 +1228,14 @@ func init() {
         }
       },
       "post": {
+        "security": [
+          {
+            "OAuth2": [
+              "uid",
+              "write"
+            ]
+          }
+        ],
         "description": "Creates a new infrastructure account\n",
         "tags": [
           "InfrastructureAccounts"
@@ -1285,6 +1324,14 @@ func init() {
         }
       },
       "patch": {
+        "security": [
+          {
+            "OAuth2": [
+              "uid",
+              "write"
+            ]
+          }
+        ],
         "description": "update an infrastructure account.",
         "tags": [
           "InfrastructureAccounts"
@@ -2328,7 +2375,8 @@ func init() {
       "flow": "password",
       "tokenUrl": "https://info.services.auth.zalando.com/oauth2/tokeninfo",
       "scopes": {
-        "uid": "Unique identifier of the user accessing the service."
+        "uid": "Unique identifier of the user accessing the service.",
+        "write": "Allows write"
       }
     }
   },

--- a/example/swagger.yaml
+++ b/example/swagger.yaml
@@ -6,7 +6,7 @@ info:
   description: Registry to store information about infrastructure accounts and Kubernetes clusters.
 
 schemes:
-    - "https"
+  - "https"
 basePath: /
 produces:
   - application/json
@@ -20,9 +20,10 @@ securityDefinitions:
     tokenUrl: https://info.services.auth.zalando.com/oauth2/tokeninfo
     scopes:
       uid: Unique identifier of the user accessing the service.
+      write: Allows write
 
 security:
-  - OAuth2: [uid]
+  - OAuth2: [ uid ]
 
 paths:
   '/infrastructure-accounts':
@@ -31,6 +32,8 @@ paths:
       tags:
         - InfrastructureAccounts
       operationId: listInfrastructureAccounts
+      security:
+        - OAuth2: [ uid ] # same as root level security, could be omitted
       responses:
         200:
           description: List of all infrastructure accounts.
@@ -40,7 +43,7 @@ paths:
               items:
                 type: array
                 items:
-                    '$ref': '#/definitions/InfrastructureAccount'
+                  '$ref': '#/definitions/InfrastructureAccount'
         401:
           description: Unauthorized
         403:
@@ -56,6 +59,8 @@ paths:
       tags:
         - InfrastructureAccounts
       operationId: createInfrastructureAccount
+      security:
+        - OAuth2: [ uid, write ]
       parameters:
         - name: infrastructure_account
           required: true
@@ -89,6 +94,8 @@ paths:
       tags:
         - InfrastructureAccounts
       operationId: updateInfrastructureAccount
+      security:
+        - OAuth2: [ uid, write ]
       parameters:
         - $ref: '#/parameters/account_id'
         - name: infrastructure_account
@@ -325,7 +332,7 @@ paths:
     delete:
       summary: Delete cluster
       description: |
-         Cluster identified by the ID.
+        Cluster identified by the ID.
       tags:
         - Clusters
       operationId: deleteCluster

--- a/templates/api.gotmpl
+++ b/templates/api.gotmpl
@@ -109,21 +109,28 @@ func initializeRoutes(enableAuth bool, tokenURL string, tracer opentracing.Trace
 {{ end }}	{{ if .Authorized }}if enableAuth {
 		{{ $routeName := (pascalize .Name) }}
 		{{ $securityDefinitions := .SecurityDefinitions }}
-		{{ range .Security }}{{ range . }}{{ $name := .Name }}{{ range $i, $def := $securityDefinitions }}
-		{{ if eq $def.ID $name }}
-		{{ if eq $def.Type "oauth2" }}
+		{{ range .Security }}
+			{{ range . }}
+				{{ $name := .Name }}
+				{{ $scopes := .Scopes }}
+				{{ range $i, $def := $securityDefinitions }}
+					{{ if eq $def.ID $name }}
+						{{ if eq $def.Type "oauth2" }}
 		routeTokenURL := tokenURL
 		if routeTokenURL == "" {
 			routeTokenURL = {{printf "%q" $def.TokenURL}}
 		}
 		routes.{{ $routeName }}.Auth = ginoauth2.Auth(
-			middleware.ScopesAuth({{range $index, $scope := .Scopes}}{{if $index}},{{end}}"{{$scope}}"{{end}}),
+			middleware.ScopesAuth({{range $index, $scope := $scopes}}{{if $index}},{{end}}"{{$scope}}"{{end}}),
 			oauth2.Endpoint{
 				TokenURL: routeTokenURL,
 			},
 		)
+						{{ end }}
+					{{ end }}
+				{{ end }}
+			{{ end }}
 		{{ end }}
-		{{ end }}{{ end }}{{ end }}{{ end }}
 	}
 {{end}}
 {{end}}


### PR DESCRIPTION
Uses operation security scopes instead of `securityDefinitions` scopes
so that operation may require subset of all availbale scopes.

See https://swagger.io/specification/v2/#operation-object

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>